### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -7,46 +7,29 @@
   },
   "targetDefaults": {
     "nx-release-publish": {
-      "options": {
-        "packageRoot": "build/{projectRoot}"
-      }
+      "options": { "packageRoot": "build/{projectRoot}" }
     }
   },
   "release": {
     "projects": ["packages/*"],
     "releaseTagPattern": "v{version}",
     "changelog": {
-      "workspaceChangelog": {
-        "createRelease": "github",
-        "file": false
-      },
+      "workspaceChangelog": { "createRelease": "github", "file": false },
       "projectChangelogs": false,
-      "git": {
-        "commit": false,
-        "stageChanges": false,
-        "tag": false
-      }
+      "git": { "commit": false, "stageChanges": false, "tag": false }
     },
     "version": {
-      "git": {
-        "commit": false,
-        "stageChanges": false,
-        "tag": false
-      },
+      "git": { "commit": false, "stageChanges": false, "tag": false },
       "currentVersionResolver": "registry",
       "manifestRootsToUpdate": ["build/{projectRoot}"],
-      "versionActionsOptions": {
-        "skipLockFileUpdate": true
-      }
+      "versionActionsOptions": { "skipLockFileUpdate": true }
     }
   },
   "plugins": [
     {
       "plugin": "@nx/js/typescript",
       "options": {
-        "typecheck": {
-          "targetName": "typecheck"
-        },
+        "typecheck": { "targetName": "typecheck" },
         "build": {
           "targetName": "build",
           "configName": "tsconfig.lib.json",
@@ -55,5 +38,7 @@
         }
       }
     }
-  ]
+  ],
+  "nxCloudId": "694aedb8007290b46b16d83b",
+  "nxCloudUrl": "https://staging.nx.app"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://staging.nx.app/orgs/66bdeeaecff095a682d09dcc/workspaces/694aedb8007290b46b16d83b

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.