### PR TITLE
fix: support tailwindcss source() import variant

### DIFF
--- a/packages/tailwind-sync-plugin/e2e/update-tailwind-globs.e2e.spec.ts
+++ b/packages/tailwind-sync-plugin/e2e/update-tailwind-globs.e2e.spec.ts
@@ -247,7 +247,7 @@ export default { plugins: [tailwindcss()] };`
     );
     updateFile(
       `apps/${app}/src/styles.css`,
-      `@import 'tailwindcss source(none)';
+      `@import 'tailwindcss' source(none);
 
 .existing-content { color: red; }`
     );
@@ -274,12 +274,62 @@ export default { plugins: [tailwindcss()] };`
     expect(css).toContain(lib);
 
     // Verify order: import should come BEFORE managed block
-    const importIndex = css.indexOf("@import 'tailwindcss source(none)'");
+    const importIndex = css.indexOf("@import 'tailwindcss' source(none)");
     const managedBlockIndex = css.indexOf('nx-tailwind-sources:start');
     expect(importIndex).toBeLessThan(managedBlockIndex);
 
     // Verify existing content is preserved
     expect(css).toContain('.existing-content { color: red; }');
+  });
+
+  it('should add managed block after @import tailwindcss source("./app")', () => {
+    const app = uniq('app');
+    const lib = uniq('lib');
+
+    updateFile(
+      `apps/${app}/project.json`,
+      JSON.stringify({
+        name: app,
+        root: `apps/${app}`,
+        sourceRoot: `apps/${app}/src`,
+        implicitDependencies: [lib],
+      })
+    );
+    updateFile(
+      `apps/${app}/src/styles.css`,
+      `@import "tailwindcss" source("./app");
+
+.existing-content { color: blue; }`
+    );
+    updateFile(`apps/${app}/src/main.ts`, `console.log('app');`);
+
+    updateFile(
+      `libs/${lib}/project.json`,
+      JSON.stringify({
+        name: lib,
+        root: `libs/${lib}`,
+        sourceRoot: `libs/${lib}/src`,
+      })
+    );
+    updateFile(`libs/${lib}/src/index.ts`, `export const x = 1;`);
+
+    runNxCommand(`g @juristr/nx-tailwind-sync:update-tailwind-globs`, {
+      silenceError: true,
+    });
+
+    const css = readFile(`apps/${app}/src/styles.css`);
+
+    // Verify managed block exists
+    expect(css).toContain('nx-tailwind-sources:start');
+    expect(css).toContain(lib);
+
+    // Verify order: import should come BEFORE managed block
+    const importIndex = css.indexOf('@import "tailwindcss" source("./app")');
+    const managedBlockIndex = css.indexOf('nx-tailwind-sources:start');
+    expect(importIndex).toBeLessThan(managedBlockIndex);
+
+    // Verify existing content is preserved
+    expect(css).toContain('.existing-content { color: blue; }');
   });
 
   it('should update multiple apps with tailwind in monorepo', () => {

--- a/packages/tailwind-sync-plugin/src/generators/update-tailwind-globs.ts
+++ b/packages/tailwind-sync-plugin/src/generators/update-tailwind-globs.ts
@@ -35,7 +35,7 @@ function findTailwindCssFile(
   for (const relPath of searchPaths) {
     const fullPath = join(projectRoot, relPath);
     const content = tree.read(fullPath)?.toString();
-    if (content?.match(/@import\s+['"]tailwindcss[^'"]*['"]/)) {
+    if (content?.match(/@import\s+['"]tailwindcss[^'"]*['"](\s+source\([^)]*\))?/)) {
       return fullPath;
     }
   }
@@ -216,7 +216,7 @@ function updateSourceDirectives(
   );
 
   // Try to find @import 'tailwindcss' first
-  const tailwindImportRegex = /@import\s+['"]tailwindcss[^'"]*['"];/;
+  const tailwindImportRegex = /@import\s+['"]tailwindcss[^'"]*['"](\s+source\([^)]*\))?;/;
   const tailwindImportMatch = cleanedContent.match(tailwindImportRegex);
 
   // If not found, look for any @import statement


### PR DESCRIPTION
## Summary
- Fix regex to match `@import "tailwindcss" source(...)` where source() is outside quotes
- Fix existing test to use correct Tailwind v4 syntax
- Add e2e test for `source("./app")` import ordering

## Problem
When `styles.css` contains `@import "tailwindcss" source("./app");`, the regex didn't match it because source() is outside quotes. This caused @source directives to be prepended instead of inserted after the import.

## Test plan
- [ ] Run `pnpm nx e2e tailwind-sync-plugin` to verify new test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)