### PR TITLE
fix: normalize backslashes in @source paths (Windows)

### DIFF
--- a/packages/tailwind-sync-plugin/e2e/source-directives.e2e.spec.ts
+++ b/packages/tailwind-sync-plugin/e2e/source-directives.e2e.spec.ts
@@ -65,6 +65,10 @@ describe('source-directives e2e', () => {
     expect(css).toContain('nx-tailwind-sources:end');
     expect(css).toContain(`@source`);
     expect(css).toContain(lib);
+
+    // Verify no backslashes in paths (Windows compatibility, #5)
+    const sourceMatch = css.match(/@source\s+"([^"]+)"/);
+    expect(sourceMatch?.[1]).not.toContain('\\');
   });
 
   it('should add @source for transitive dependencies', () => {

--- a/packages/tailwind-sync-plugin/src/generators/source-directives.ts
+++ b/packages/tailwind-sync-plugin/src/generators/source-directives.ts
@@ -170,7 +170,10 @@ function updateSourceDirectives(
     const project = projectGraph.nodes[dep];
     if (project && project.data.root) {
       // Calculate relative path from CSS file directory to dependency root
-      const relativePath = relative(cssDir, project.data.root);
+      const relativePath = relative(cssDir, project.data.root).replace(
+        /\\/g,
+        '/'
+      );
       sourceDirectives.push(`@source "${relativePath}";`);
     }
   });


### PR DESCRIPTION
## Summary
- Normalize `path.relative()` output to use forward slashes, fixing broken `@source` directives on Windows
- Add test assertion verifying no backslashes in generated paths

Closes #5