### PR TITLE
chore: update pnpm to 11.22.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.8.0
           run_install: false
 
       # This enables task distribution via Nx Cloud
@@ -34,7 +33,7 @@ jobs:
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.12.1
+          run_install: false
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -6,11 +6,7 @@
     "release": "pnpm nx run-many --target=build && tsx scripts/release.ts"
   },
   "private": true,
-  "pnpm": {
-    "overrides": {
-      "minimatch": ">=10.0.0"
-    }
-  },
+  "packageManager": "pnpm@11.22.0",
   "devDependencies": {
     "@nx/js": "22.1.3",
     "@nx/plugin": "^22.3.3",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,13 @@
 packages:
-  - "packages/*"
+  - 'packages/*'
 
 autoInstallPeers: true
+
+overrides:
+  minimatch: '>=10.0.0'
+
+allowBuilds:
+  '@swc/core': true
+  esbuild: true
+  nx: true
+  unrs-resolver: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,9 @@
   "extends": "./tsconfig.base.json",
   "compileOnSave": false,
   "files": [],
-  "references": []
+  "references": [
+    {
+      "path": "./packages/tailwind-sync-plugin"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Updates pnpm from the pinned `9.8.0` (ci.yml) / `10.12.1` (publish.yml) to **11.22.0**, the current latest.

pnpm is now pinned once via the `packageManager` field in `package.json`, and the hardcoded `version:` inputs were dropped from both `pnpm/action-setup@v4` steps, so CI and local share a single source of truth.

Three pnpm 10/11 breaking changes had to be handled:

- **`pnpm.overrides` in package.json is no longer read by pnpm 11.** The `minimatch: ">=10.0.0"` override added in 12b4703 (ReDoS fix) would have been silently dropped, churning ~1275 lines of the lockfile. Moved to `pnpm-workspace.yaml`.
- **pnpm 10+ blocks dependency postinstall scripts unless allowlisted.** ci.yml was on pnpm 9, which ran them automatically. pnpm 11 gates this on `allowBuilds` (not the older `onlyBuiltDependencies`), added for `@swc/core`, `esbuild`, `nx`, `unrs-resolver`.
- **pnpm 11 requires Node >= 22.13.** ci.yml pinned `node-version: 20`, bumped to 22. publish.yml was already on 24.

`pnpm-lock.yaml` is unchanged: lockfileVersion 9.0 is shared by pnpm 9/10/11 and `--frozen-lockfile` passes as-is.

### Out-of-scope change included deliberately

`tsconfig.json` gains a project reference to `packages/tailwind-sync-plugin`, generated by `nx sync`. This is pre-existing drift on `main`, not introduced here, but the nx sync check hard-fails *any* nx invocation, so the PR cannot go green without it. Happy to split it out.

### Verification

Locally on pnpm 11.22.0: clean `pnpm install --frozen-lockfile` with all postinstalls running, plus `build`, `typecheck` and all 9 e2e tests passing.

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69d94d95f9de2b9cbf80f6c5/sessions/update-pnpm-version-4c563a76">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->